### PR TITLE
bug fixing for MPNetEntityInjector and run file

### DIFF
--- a/kaping/entity_injection.py
+++ b/kaping/entity_injection.py
@@ -31,7 +31,7 @@ class MPNetEntityInjector:
 		"""
 		return self.model.encode(texts)
 
-	def top_k_triple_extractor(self, question: np.ndarray, triples: np.ndarray, k=10, random=False):
+	def top_k_triple_extractor(self, question: np.ndarray, triples_emb: np.ndarray, triples: list, k=10, random=False):
 		"""
 		Retrieve the top k triples of KGs used as context for the question
 
@@ -42,14 +42,14 @@ class MPNetEntityInjector:
 		:return: list of triples
 		"""
 		# in case number of triples is fewer than k 
-		if len(triples) < k:
-			k = len(triples)
+		if len(triples_emb) < k:
+			k = len(triples_emb)
 
 		if random:
-			return random.sample(infos, k)
+			return random.sample(triples, k)
 
 		# if not the baseline but the top k most similar
-		similarities = cosine_similarity(question, triples)
+		similarities = cosine_similarity(question, triples_emb)
 		top_k_indices = np.argsort(similarities[0])[-k:][::-1]
 
 		return [triples[index] for index in top_k_indices]
@@ -90,8 +90,9 @@ class MPNetEntityInjector:
 		emb_triples = self.sentence_embedding(triples)
 
 		# retrieve the top k triples
-		top_k_triples = self.top_k_triple_extractor(emb_question, emb_triples, k=k, random=random)
+		top_k_triples = self.top_k_triple_extractor(emb_question, emb_triples, triples, k=k, random=random)
 
 		# create prompt as input
-		return self.injection(question, top_k_triples)
+		# when injecting, the question should be string
+		return self.injection(question[0], top_k_triples)
 

--- a/kaping/entity_verbalization.py
+++ b/kaping/entity_verbalization.py
@@ -28,34 +28,34 @@ class RebelEntityVerbalizer:
 		"""
 
 		triplets = []
-	    relation, subject, relation, object_ = '', '', '', ''
-	    text = text.strip()
-	    current = 'x'
-	    for token in text.replace("<s>", "").replace("<pad>", "").replace("</s>", "").split():
-	        if token == "<triplet>":
-	            current = 't'
-	            if relation != '':
-	                triplets.append({'head': subject.strip(), 'type': relation.strip(),'tail': object_.strip()})
-	                relation = ''
-	            subject = ''
-	        elif token == "<subj>":
-	            current = 's'
-	            if relation != '':
-	                triplets.append({'head': subject.strip(), 'type': relation.strip(),'tail': object_.strip()})
-	            object_ = ''
-	        elif token == "<obj>":
-	            current = 'o'
-	            relation = ''
-	        else:
-	            if current == 't':
-	                subject += ' ' + token
-	            elif current == 's':
-	                object_ += ' ' + token
-	            elif current == 'o':
-	                relation += ' ' + token
-	    if subject != '' and relation != '' and object_ != '':
-	        triplets.append({'head': subject.strip(), 'type': relation.strip(),'tail': object_.strip()})
-	    return triplets
+		relation, subject, relation, object_ = '', '', '', ''
+		text = text.strip()
+		current = 'x'
+		for token in text.replace("<s>", "").replace("<pad>", "").replace("</s>", "").split():
+			if token == "<triplet>":
+				current = 't'
+				if relation != '':
+					triplets.append({'head': subject.strip(), 'type': relation.strip(),'tail': object_.strip()})
+					relation = ''
+				subject = ''
+			elif token == "<subj>":
+				current = 's'
+				if relation != '':
+					triplets.append({'head': subject.strip(), 'type': relation.strip(),'tail': object_.strip()})
+				object_ = ''
+			elif token == "<obj>":
+				current = 'o'
+				relation = ''
+			else:
+				if current == 't':
+					subject += ' ' + token
+				elif current == 's':
+					object_ += ' ' + token
+				elif current == 'o':
+					relation += ' ' + token
+		if subject != '' and relation != '' and object_ != '':
+			triplets.append({'head': subject.strip(), 'type': relation.strip(),'tail': object_.strip()})
+		return triplets
 
 
 	def text_relation(self, text: str):

--- a/kaping/model.py
+++ b/kaping/model.py
@@ -30,7 +30,8 @@ def pipeline(config, question: str, device=-1):
 		knowledge_triples.extend(verbalizer(entity, entity_title))
 
 	# entity injection as final prompt as input
-	prompt = injector(question, knowledge_triples, k=config.k, random=config.random, no_knowledge=config.no_knowledge)
+	# quetion should be a list of string
+	prompt = injector([question], knowledge_triples, k=config.k, random=config.random, no_knowledge=config.no_knowledge)
 
 	return prompt
 

--- a/run.py
+++ b/run.py
@@ -42,7 +42,7 @@ def main():
 		results.append(qa_pair)
 
 		# evaluate to calculate the accuracy
-		evaluated.append(evaluated(qa_pair.answer, predicted_answer))
+		evaluated.append(evaluate(qa_pair.answer, predicted_answer))
 
 	msg = ""
 	if args.no_knowledge:


### PR DESCRIPTION
Dear KAPING author,

While replicating your source code, I encountered the following bugs, which have been fixed in this pull request:
1. In the `call` function of MPNetEntityInjector, the type of the `question` is expected to be in list format, but a string format was input when using the `call` function. I have adjusted the input in `model.py` to be a list. Additionally, in the `injection` function of `MPNetEntityInjector`, the `question` is expected to be a string, which has also been correspondingly adjusted.
2. The `top_k_triple_extractor` function of `MPNetEntityInjector` incorrectly outputted the triples embedding instead of the intended triples list. The reason is that the function only received the triples embedding as input. This has been fixed. Moreover, when the random flag is set to True, the `infos` variable does not exist. Based on my understanding of your paper, I have adjusted it to `triples`.
3. In `run.py`, `evaluated` is a list, and `evaluate` is the assessment function. It seems you have confused the two in the source code.
4. There was an issue with the format of `entity_verbalization.py`, which has now been fixed.

I hope you will accept this pull request to facilitate the replication of this paper in the future.