### PR TITLE
Add EM/F1/BLEU/ROUGE metrics and switch to loguru logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Workflow
+
+Never edit directly on `main`. Always create a feature branch first (e.g. `git checkout -b feature/<short-name>`) before making changes.
+
+## Commands
+
+Install (Poetry, Python 3.11/3.12 only):
+
+```sh
+poetry install --with dev
+```
+
+Lint (ruff via pre-commit — same step CI runs):
+
+```sh
+pre-commit run --all-files
+```
+
+Tests:
+
+```sh
+# Default: unit + e2e, no real ML downloads (this is what CI runs)
+poetry run pytest -m "not system and not slow" -v
+
+# Run a single test
+poetry run pytest tests/unit/test_qa_evaluate.py::TestEvaluate::test_exact_match -v
+
+# Full suite (requires network + model downloads, very slow)
+poetry run pytest -v
+```
+
+Run the pipeline:
+
+```sh
+poetry run python run.py --input <mintaka_dataset.json>
+poetry run python run.py -h   # all flags
+```
+
+Docker entrypoint is `run.py`, so `docker run --rm kaping --input ...` works after `docker build -t kaping .`.
+
+## Architecture
+
+KAPING is a 3-stage retrieval-augmented prompt builder, then an HF inference call. Per-question flow lives in `kaping/model.py::pipeline()`:
+
+1. **Entity extraction** (`kaping/entity_extractor.py`) — ReFInED links question entities to Wikidata.
+2. **Entity verbalization** (`kaping/entity_verbalization.py`) — REBEL extracts relation triples from each entity's Wikipedia page.
+3. **Entity injection** (`kaping/entity_injection.py`) — MPNet (`all-mpnet-base-v2`) embeds both question and triples, cosine-similarity picks top-k, and the triples are spliced into a leading prompt template. `--random` swaps top-k for random-k (baseline); `--no_knowledge` skips retrieval entirely (prompt-only baseline).
+
+The resulting prompt goes to `qa/qa_inference.py`, which dispatches to a HuggingFace pipeline. **The QA model generates the answer from the full Question+Context prompt — it does not extract a span.** `--inference_task` (`text2text-generation` vs `text-generation`) must match the model architecture. `gpt2` requires `text-generation`; this is checked in `run.py` and exits early on mismatch.
+
+Evaluation (`qa/qa_evaluate.py`) computes five metrics, all aggregated by `corpus_metrics(answers, predictions)` and printed by `run.py`:
+
+| Metric | What it measures |
+|--------|------------------|
+| `containment` | Original loose substring check: `gold in predicted`. Case-sensitive, no normalization. |
+| `exact_match` | SQuAD-style normalized equality (lowercase, strip `a`/`an`/`the`, strip punctuation, collapse whitespace). |
+| `token_f1` | Token-level F1 over normalized text. Standard SQuAD-style QA F1. |
+| `bleu_1` | Sentence-level BLEU-1 (clipped unigram precision × brevity penalty) over normalized text. |
+| `rouge_l` | LCS-based ROUGE-L F-measure over normalized text. |
+
+All metrics except `containment` apply `normalize_answer`, so a standalone "a"/"an"/"the" token gets stripped — write tests with non-article tokens.
+
+### Non-obvious gotchas
+
+- `pipeline()` instantiates fresh `RefinedEntityExtractor`, `RebelEntityVerbalizer`, and `MPNetEntityInjector` **per question** (`kaping/model.py:20-22`). For multi-question runs this reloads three heavy models each iteration. Don't refactor casually — but be aware before benchmarking.
+- `arguments.py` defaults `--model_name` to `bert-large-uncased` with `--inference_task=text2text-generation`. BERT is not a seq2seq model; this combination is what the original reimplementation used, not a bug to "fix."
+- Unit tests stub heavy ML deps at import time via `tests/unit/conftest.py` — it inserts `MagicMock()` into `sys.modules` for `sentence_transformers`, `transformers`, `refined`, and `sklearn.metrics.pairwise` *before* test modules import them. New unit tests that touch these libraries must either (a) accept the mock or (b) move to `tests/e2e/` or `tests/system/`.
+- Pytest markers `slow` and `system` are deselected by default in CI. Mark any test needing real model downloads or full environment setup accordingly, or it will silently run (and likely fail) in CI.
+
+## Dataset format
+
+`qa/qa_preprocessing.py::load_dataset` expects Mintaka JSON: each record needs `question`, `questionEntity[].mention`, `answer`, `complexityType`. Loader returns a list of `Pair` objects; `Pair.pr_answer` is filled in by `run.py` after inference and written to the output CSV.

--- a/kaping/entity_extractor.py
+++ b/kaping/entity_extractor.py
@@ -4,6 +4,7 @@ an entity linking framework
 
 """
 
+from loguru import logger
 from refined.inference.processor import Refined
 
 
@@ -42,7 +43,7 @@ class RefinedEntityExtractor:
 
         # define set of entity
         entity_set = []
-        print("***** Entity Extraction *****")
+        logger.info("***** Entity Extraction *****")
         entity_set = [
             (span.text, span.predicted_entity.wikipedia_entity_title) for span in spans
         ]

--- a/kaping/entity_verbalization.py
+++ b/kaping/entity_verbalization.py
@@ -9,6 +9,7 @@ Steps:
 
 import requests
 from bs4 import BeautifulSoup
+from loguru import logger
 from transformers import pipeline
 
 
@@ -129,9 +130,9 @@ class RebelEntityVerbalizer:
                     final = [f"({', '.join(rela.values())})" for rela in relations]
                     infos.extend(final)
             else:
-                print("No paragraphs")
+                logger.warning("No paragraphs")
         else:
-            print("No data")
+            logger.warning("No data")
         return list(set(infos))
 
     def __call__(self, entity, entity_title=None):
@@ -151,5 +152,5 @@ class RebelEntityVerbalizer:
          ....,]
         """
 
-        print("***** Verbalization *****")
+        logger.info("***** Verbalization *****")
         return self._get_wikipedia_paragraph(entity, entity_title)

--- a/poetry.lock
+++ b/poetry.lock
@@ -305,7 +305,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "cuda-bindings"
@@ -862,6 +862,25 @@ files = [
     {file = "lmdb-2.2.0-pp310-pypy310_pp73-manylinux_2_38_x86_64.whl", hash = "sha256:a678e0ffcdc366a197b60e1f3e28e7c425031b35d5cbd73c0f08290ee7791ca6"},
     {file = "lmdb-2.2.0.tar.gz", hash = "sha256:53020e20305c043ea6e68089bc242d744fba6073cdb268332299ba6dda2886d4"},
 ]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+description = "Python logging made (stupidly) simple"
+optional = false
+python-versions = "<4.0,>=3.5"
+groups = ["main"]
+files = [
+    {file = "loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c"},
+    {file = "loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (==8.1.3) ; python_version >= \"3.11\"", "build (==1.2.2) ; python_version >= \"3.11\"", "colorama (==0.4.5) ; python_version < \"3.8\"", "colorama (==0.4.6) ; python_version >= \"3.8\"", "exceptiongroup (==1.1.3) ; python_version >= \"3.7\" and python_version < \"3.11\"", "freezegun (==1.1.0) ; python_version < \"3.8\"", "freezegun (==1.5.0) ; python_version >= \"3.8\"", "mypy (==0.910) ; python_version < \"3.6\"", "mypy (==0.971) ; python_version == \"3.6\"", "mypy (==1.13.0) ; python_version >= \"3.8\"", "mypy (==1.4.1) ; python_version == \"3.7\"", "myst-parser (==4.0.0) ; python_version >= \"3.11\"", "pre-commit (==4.0.1) ; python_version >= \"3.9\"", "pytest (==6.1.2) ; python_version < \"3.8\"", "pytest (==8.3.2) ; python_version >= \"3.8\"", "pytest-cov (==2.12.1) ; python_version < \"3.8\"", "pytest-cov (==5.0.0) ; python_version == \"3.8\"", "pytest-cov (==6.0.0) ; python_version >= \"3.9\"", "pytest-mypy-plugins (==1.9.3) ; python_version >= \"3.6\" and python_version < \"3.8\"", "pytest-mypy-plugins (==3.1.0) ; python_version >= \"3.8\"", "sphinx-rtd-theme (==3.0.2) ; python_version >= \"3.11\"", "tox (==3.27.1) ; python_version < \"3.8\"", "tox (==4.23.2) ; python_version >= \"3.8\"", "twine (==6.0.1) ; python_version >= \"3.11\""]
 
 [[package]]
 name = "markdown"
@@ -2723,7 +2742,23 @@ markupsafe = ">=2.1.1"
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
 
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+description = "A small Python utility to set file creation time on Windows"
+optional = false
+python-versions = ">=3.5"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390"},
+    {file = "win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0"},
+]
+
+[package.extras]
+dev = ["black (>=19.3b0) ; python_version >= \"3.6\"", "pytest (>=4.6.2)"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "7c26861b7ded8e5405993075bf94dd56d12a03713c0aad2044e29c5f373536f0"
+content-hash = "3f96eff89fd0206d9e13dac8c10bd1f4206e9ba4924383184fed4bdb6b478d7a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ package-mode = false
 python = ">=3.11,<3.13"
 beautifulsoup4 = "4.12.2"
 bs4 = "0.0.1"
+loguru = ">=0.7.2"
 numpy = ">=1.26.1"
 scikit-learn = ">=1.5.0"
 sentence-transformers = ">=3.0.0"

--- a/qa/qa_evaluate.py
+++ b/qa/qa_evaluate.py
@@ -1,21 +1,122 @@
 """
-This contains a simple script to calculate the matching score after inference
+Evaluation metrics for KAPING QA outputs.
+
+All per-example metrics take (gold_answer, predicted_answer) and return a score
+in [0, 1] (float) or a boolean. `corpus_metrics` aggregates a parallel list of
+gold/predicted answers into mean scores.
+
+Normalization (`normalize_answer`) follows the SQuAD convention: lowercase,
+strip articles, strip punctuation, collapse whitespace. It is applied by every
+metric below *except* `evaluate`, which is preserved as the original loose
+substring-containment check (case-sensitive, no normalization).
 """
 
+import math
+import re
+import string
+from collections import Counter
 
-def evaluate(answer: str, predicted: str):
-    """
-    Evaluate if the predicted answer contains the true answer
-    :param answer: true answer (gold label)
-    :param predicted: generated answer (predicted label)
-    :return: True/False (boolean)
-    """
+
+def normalize_answer(s: str) -> str:
+    """SQuAD-style normalization: lowercase, drop articles + punctuation, collapse whitespace."""
+    s = s.lower()
+    s = re.sub(r"\b(a|an|the)\b", " ", s)
+    s = "".join(ch for ch in s if ch not in string.punctuation)
+    return " ".join(s.split())
+
+
+def evaluate(answer: str, predicted: str) -> bool:
+    """Loose substring containment (legacy metric — case-sensitive, no normalization)."""
     return answer in predicted
 
 
-def accuracy(evaluated):
-    """
-    Calculate the accuracy
-    :param evaluated:
-    """
-    return evaluated.count(True) / len(evaluated)
+def exact_match(answer: str, predicted: str) -> bool:
+    """Normalized exact match."""
+    return normalize_answer(answer) == normalize_answer(predicted)
+
+
+def token_f1(answer: str, predicted: str) -> float:
+    """Token-level F1 over normalized text (SQuAD convention)."""
+    gold_tokens = normalize_answer(answer).split()
+    pred_tokens = normalize_answer(predicted).split()
+
+    if not gold_tokens or not pred_tokens:
+        # Both empty -> perfect match; otherwise no overlap is possible.
+        return float(gold_tokens == pred_tokens)
+
+    overlap = sum((Counter(gold_tokens) & Counter(pred_tokens)).values())
+    if overlap == 0:
+        return 0.0
+    precision = overlap / len(pred_tokens)
+    recall = overlap / len(gold_tokens)
+    return 2 * precision * recall / (precision + recall)
+
+
+def bleu_1(answer: str, predicted: str) -> float:
+    """Sentence-level BLEU-1 (clipped unigram precision with brevity penalty)."""
+    gold_tokens = normalize_answer(answer).split()
+    pred_tokens = normalize_answer(predicted).split()
+    if not gold_tokens or not pred_tokens:
+        return 0.0
+
+    gold_counts = Counter(gold_tokens)
+    pred_counts = Counter(pred_tokens)
+    clipped = sum(min(c, gold_counts[t]) for t, c in pred_counts.items())
+    precision = clipped / len(pred_tokens)
+
+    if len(pred_tokens) >= len(gold_tokens):
+        bp = 1.0
+    else:
+        bp = math.exp(1 - len(gold_tokens) / len(pred_tokens))
+
+    return bp * precision
+
+
+def rouge_l(answer: str, predicted: str) -> float:
+    """ROUGE-L F-measure based on longest common subsequence of tokens."""
+    gold_tokens = normalize_answer(answer).split()
+    pred_tokens = normalize_answer(predicted).split()
+    if not gold_tokens or not pred_tokens:
+        return 0.0
+
+    m, n = len(gold_tokens), len(pred_tokens)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(m):
+        for j in range(n):
+            if gold_tokens[i] == pred_tokens[j]:
+                dp[i + 1][j + 1] = dp[i][j] + 1
+            else:
+                dp[i + 1][j + 1] = max(dp[i][j + 1], dp[i + 1][j])
+    lcs = dp[m][n]
+    if lcs == 0:
+        return 0.0
+    precision = lcs / n
+    recall = lcs / m
+    return 2 * precision * recall / (precision + recall)
+
+
+def accuracy(evaluated) -> float:
+    """Mean of a list of booleans (or numeric scores in [0, 1])."""
+    if not evaluated:
+        raise ValueError("Cannot compute accuracy over an empty list")
+    return sum(bool(x) if isinstance(x, bool) else x for x in evaluated) / len(
+        evaluated
+    )
+
+
+def corpus_metrics(answers: list, predictions: list) -> dict:
+    """Compute mean of every per-example metric across parallel answer/prediction lists."""
+    if len(answers) != len(predictions):
+        raise ValueError("answers and predictions must have the same length")
+    if not answers:
+        raise ValueError("Cannot compute metrics over an empty dataset")
+
+    pairs = list(zip(answers, predictions))
+    n = len(pairs)
+    return {
+        "containment": sum(evaluate(a, p) for a, p in pairs) / n,
+        "exact_match": sum(exact_match(a, p) for a, p in pairs) / n,
+        "token_f1": sum(token_f1(a, p) for a, p in pairs) / n,
+        "bleu_1": sum(bleu_1(a, p) for a, p in pairs) / n,
+        "rouge_l": sum(rouge_l(a, p) for a, p in pairs) / n,
+    }

--- a/qa/qa_inference.py
+++ b/qa/qa_inference.py
@@ -2,6 +2,7 @@
 This contains the script to proceed the QA inference with some models
 """
 
+from loguru import logger
 from transformers import pipeline
 
 
@@ -25,7 +26,7 @@ def qa_inference(task: str, model_name: str, prompt: str, device=-1):
 
     # for bert-large-uncased, t5-small, t5-base, t5-large
     if task == "text2text-generation":
-        print("This task is used for bert-large-uncased and t5 models")
+        logger.info("This task is used for bert-large-uncased and t5 models")
         qa_pipeline = pipeline(task, model=model_name, device=device)
         answer = qa_pipeline(prompt)
         return answer[0]["generated_text"]
@@ -34,7 +35,7 @@ def qa_inference(task: str, model_name: str, prompt: str, device=-1):
     # In this inference, as huggingface pipeline does not support text2text-generation for gpt2,
     # hence text-generation was used instead
     elif task == "text-generation":
-        print("This task is used for GPT2 model")
+        logger.info("This task is used for GPT2 model")
         qa_pipeline = pipeline(
             task, model=model_name, max_new_tokens=200, device=device
         )

--- a/run.py
+++ b/run.py
@@ -1,9 +1,12 @@
-from kaping.model import pipeline
-from qa.qa_inference import qa_inference
-from qa.qa_evaluate import accuracy, evaluate
-from qa.qa_preprocessing import load_dataset
-from arguments import k_parser
 import sys
+
+from loguru import logger
+
+from arguments import k_parser
+from kaping.model import pipeline
+from qa.qa_evaluate import corpus_metrics
+from qa.qa_inference import qa_inference
+from qa.qa_preprocessing import load_dataset
 
 
 def main():
@@ -12,11 +15,11 @@ def main():
 
     # some simple tests before running
     if not args.input:
-        print("No input file, can not run")
+        logger.error("No input file, can not run")
         sys.exit(1)
 
     if args.inference_task == "text2text-generation" and args.model_name == "gpt2":
-        print(
+        logger.error(
             "gpt2 is compatible with text-generation only, change --inference_task if you want to use gpt2"
         )
         sys.exit(1)
@@ -26,9 +29,6 @@ def main():
 
     # set up results
     results = []
-
-    # set up evaluated to calculate the accuracy
-    evaluated = []
 
     # ------- run through each question-answer pair and run KAPING
     for qa_pair in dataset:
@@ -47,18 +47,18 @@ def main():
         # add new qa_pair for output file
         results.append(qa_pair)
 
-        # evaluate to calculate the accuracy
-        evaluated.append(evaluate(qa_pair.answer, predicted_answer))
-
     msg = ""
     if args.no_knowledge:
         msg = " without knowledge"
     else:
         msg = " with random knowledge" if args.random else " using KAPING"
 
-    print(
-        f"Accuracy for infering QA task on {args.model_name}{msg}: {accuracy(evaluated):.2f}"
+    metrics = corpus_metrics(
+        [r.answer for r in results], [r.pr_answer for r in results]
     )
+    logger.info(f"Metrics for inferring QA task on {args.model_name}{msg}:")
+    for name, score in metrics.items():
+        logger.info(f"  {name}: {score:.4f}")
 
     output = (
         args.output
@@ -66,7 +66,7 @@ def main():
         else f"./mintaka_predicted_{args.model_name}_{msg[1:]}.csv"
     )
 
-    print(f"Save results in {output}")
+    logger.info(f"Save results in {output}")
     with open(output, "w") as f2w:
         for qa_pair in results:
             f2w.write(

--- a/tests/unit/test_qa_evaluate.py
+++ b/tests/unit/test_qa_evaluate.py
@@ -1,5 +1,14 @@
 import pytest
-from qa.qa_evaluate import accuracy, evaluate
+from qa.qa_evaluate import (
+    accuracy,
+    bleu_1,
+    corpus_metrics,
+    evaluate,
+    exact_match,
+    normalize_answer,
+    rouge_l,
+    token_f1,
+)
 
 
 class TestEvaluate:
@@ -44,3 +53,157 @@ class TestAccuracy:
 
     def test_one_out_of_three(self):
         assert pytest.approx(accuracy([True, False, False])) == 1 / 3
+
+    def test_numeric_scores(self):
+        # also works for floats in [0, 1]
+        assert pytest.approx(accuracy([1.0, 0.5, 0.0])) == 0.5
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            accuracy([])
+
+
+class TestNormalizeAnswer:
+    def test_lowercases(self):
+        assert normalize_answer("PARIS") == "paris"
+
+    def test_strips_articles(self):
+        assert normalize_answer("the Eiffel Tower") == "eiffel tower"
+
+    def test_strips_punctuation(self):
+        assert normalize_answer("Paris, France!") == "paris france"
+
+    def test_collapses_whitespace(self):
+        assert normalize_answer("  Paris   France  ") == "paris france"
+
+    def test_strips_a_an_the_only_as_words(self):
+        # "Tha" should not lose its leading characters — only whole-word articles
+        assert normalize_answer("Thames") == "thames"
+
+
+class TestExactMatch:
+    def test_case_insensitive(self):
+        assert exact_match("Paris", "paris") is True
+
+    def test_article_insensitive(self):
+        assert exact_match("Eiffel Tower", "the Eiffel Tower") is True
+
+    def test_punctuation_insensitive(self):
+        assert exact_match("Paris", "Paris.") is True
+
+    def test_substring_is_not_match(self):
+        assert exact_match("Jane Austen", "The author is Jane Austen.") is False
+
+    def test_mismatch(self):
+        assert exact_match("Paris", "London") is False
+
+    def test_both_empty(self):
+        assert exact_match("", "") is True
+
+
+class TestTokenF1:
+    def test_perfect_match(self):
+        assert token_f1("Jane Austen", "Jane Austen") == 1.0
+
+    def test_no_overlap(self):
+        assert token_f1("Jane Austen", "Charles Dickens") == 0.0
+
+    def test_partial_overlap(self):
+        # gold: {jane, austen} (2 tokens), pred: {jane, smith} (2 tokens), overlap=1
+        # precision = 1/2, recall = 1/2, f1 = 0.5
+        assert token_f1("Jane Austen", "Jane Smith") == pytest.approx(0.5)
+
+    def test_pred_is_longer_sentence(self):
+        # gold: {jane, austen}, pred normalized: {author, is, jane, austen} -> overlap=2
+        # precision = 2/4 = 0.5, recall = 2/2 = 1.0, f1 = 2/3
+        assert token_f1("Jane Austen", "The author is Jane Austen") == pytest.approx(
+            2 / 3
+        )
+
+    def test_normalization_applied(self):
+        assert token_f1("the Paris", "Paris.") == 1.0
+
+    def test_empty_gold_and_pred(self):
+        assert token_f1("", "") == 1.0
+
+    def test_empty_pred_only(self):
+        assert token_f1("Paris", "") == 0.0
+
+
+class TestBleu1:
+    def test_perfect_match(self):
+        assert bleu_1("Jane Austen", "Jane Austen") == pytest.approx(1.0)
+
+    def test_no_overlap(self):
+        assert bleu_1("Jane Austen", "Charles Dickens") == 0.0
+
+    def test_brevity_penalty_when_pred_shorter(self):
+        # gold len 2, pred len 1, precision 1.0, BP = exp(1 - 2/1) = exp(-1)
+        import math
+
+        assert bleu_1("Jane Austen", "Jane") == pytest.approx(math.exp(-1))
+
+    def test_no_bp_when_pred_at_least_as_long(self):
+        # precision = 2/3, no BP since pred len (3) >= gold len (2)
+        assert bleu_1("Jane Austen", "Jane Austen now") == pytest.approx(2 / 3)
+
+    def test_clipped_precision(self):
+        # gold has "jane" once; pred has "jane" 3 times — clip to 1, precision = 1/3
+        # pred len 3 >= gold len 1, so BP = 1
+        assert bleu_1("Jane", "Jane Jane Jane") == pytest.approx(1 / 3)
+
+    def test_empty_inputs(self):
+        assert bleu_1("", "anything") == 0.0
+        assert bleu_1("anything", "") == 0.0
+
+
+class TestRougeL:
+    def test_perfect_match(self):
+        assert rouge_l("Jane Austen", "Jane Austen") == pytest.approx(1.0)
+
+    def test_no_overlap(self):
+        assert rouge_l("Jane Austen", "Charles Dickens") == 0.0
+
+    def test_lcs_preserves_order(self):
+        # gold tokens: [x, y, z], pred tokens: [z, y, x]  -> LCS length = 1
+        # precision = 1/3, recall = 1/3, f1 = 1/3
+        assert rouge_l("x y z", "z y x") == pytest.approx(1 / 3)
+
+    def test_subsequence_with_gap(self):
+        # gold: [jane, austen], pred: [jane, marie, austen] -> LCS=2
+        # precision = 2/3, recall = 1.0, f1 = 0.8
+        assert rouge_l("Jane Austen", "Jane Marie Austen") == pytest.approx(0.8)
+
+    def test_empty_inputs(self):
+        assert rouge_l("", "anything") == 0.0
+        assert rouge_l("anything", "") == 0.0
+
+
+class TestCorpusMetrics:
+    def test_all_correct(self):
+        m = corpus_metrics(["Paris", "London"], ["Paris", "London"])
+        assert m["exact_match"] == 1.0
+        assert m["token_f1"] == 1.0
+        assert m["bleu_1"] == pytest.approx(1.0)
+        assert m["rouge_l"] == pytest.approx(1.0)
+        assert m["containment"] == 1.0
+
+    def test_mixed(self):
+        m = corpus_metrics(
+            ["Jane Austen", "Paris"],
+            ["The author is Jane Austen.", "London"],
+        )
+        # containment: True (first contains "Jane Austen"), False -> 0.5
+        assert m["containment"] == 0.5
+        # exact_match: first is False (whole-string compare), second False -> 0.0
+        assert m["exact_match"] == 0.0
+        # token_f1 average of (2/3) and 0.0
+        assert m["token_f1"] == pytest.approx((2 / 3) / 2)
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            corpus_metrics(["a"], ["a", "b"])
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            corpus_metrics([], [])


### PR DESCRIPTION
## Summary

- Adds SQuAD-style `normalize_answer`, `exact_match`, `token_f1`, sentence-level `bleu_1`, and `rouge_l` to `qa/qa_evaluate.py`, plus a `corpus_metrics` aggregator. `run.py` now reports all five per inference run alongside the original containment score.
- Swaps remaining `print()` debugging in `kaping/` and `qa/` for `loguru.logger` (loguru added to dependencies, lockfile refreshed).
- Seeds `CLAUDE.md` documenting the pipeline architecture, dev commands, and per-question instantiation gotcha in `kaping/model.py`.

## Test plan

- [x] `poetry run pytest -m "not system and not slow"` — 96 passed, 7 deselected
- [x] `pre-commit run --all-files` — clean (ruff + ruff-format)
- [ ] Spot-check `run.py` against a small Mintaka file once available