### PR TITLE
ci: add Dependabot config + auto-merge for patch/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Python dependencies (Poetry — pyproject.toml + poetry.lock)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # Bundle patch/minor bumps into a single PR to cut down on notification noise.
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+# Enables auto-merge on Dependabot PRs for patch/minor updates. GitHub holds the
+# merge until the required status checks (CI) pass, so nothing merges without a
+# green build. Major updates are left for manual review.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets up automated dependency maintenance so security/version PRs are opened, tested by CI, and merged automatically (patch/minor only).

## What's added
- **`.github/dependabot.yml`** — weekly updates for the `pip` (Poetry) and `github-actions` ecosystems. Patch/minor bumps are grouped into a single PR to cut notification noise.
- **`.github/workflows/dependabot-auto-merge.yml`** — on a Dependabot PR, reads the update type and enables GitHub auto-merge for **patch/minor** only. Merge is held until required CI checks pass; **major** updates stay manual.

## Companion repo settings (applied separately, not in this diff)
- `allow_auto_merge` enabled on the repo.
- `main-branch-protection` ruleset enabled with the CI jobs (`Lint`, `Unit & E2E Tests`) as required status checks — this is what makes auto-merge wait for a green build.

> Note: Dependabot **email** notifications are a personal setting (Settings → Notifications → Dependabot), not something a repo file controls. Auto-merge removes the need to act on these PRs; muting the emails is a one-time toggle in your account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)